### PR TITLE
Cat 51 get rds instances backend

### DIFF
--- a/mycrt-backend/src/capture/captureHelper.py
+++ b/mycrt-backend/src/capture/captureHelper.py
@@ -1,0 +1,10 @@
+import argparse
+import os.path
+import sys
+import boto3
+import json
+from botocore.exceptions import NoRegionError, ClientError
+
+#AWS setup
+s3 = boto3.client('s3')
+rds = boto3.client('rds')

--- a/mycrt-backend/src/capture/captureHelper.py
+++ b/mycrt-backend/src/capture/captureHelper.py
@@ -11,10 +11,13 @@ rds = boto3.client('rds')
 
 def getRDSInstances():
     DBInstances = []
-
-    response = rds.describe_db_instances()
-    DBInstancesInfo = response['DBInstances']
-    for instance in DBInstancesInfo:
-        DBInstances.append(instance['DBInstanceIdentifier'])
+    try:
+        response = rds.describe_db_instances()
+        DBInstancesInfo = response['DBInstances']
+        for instance in DBInstancesInfo:
+            DBInstances.append(instance['DBInstanceIdentifier'])
+    except ClientError as e:
+        print(e)
+        return 0
 
     return DBInstances

--- a/mycrt-backend/src/capture/captureHelper.py
+++ b/mycrt-backend/src/capture/captureHelper.py
@@ -8,3 +8,13 @@ from botocore.exceptions import NoRegionError, ClientError
 #AWS setup
 s3 = boto3.client('s3')
 rds = boto3.client('rds')
+
+def getRDSInstances():
+    DBInstances = []
+
+    response = rds.describe_db_instances()
+    DBInstancesInfo = response['DBInstances']
+    for instance in DBInstancesInfo:
+        DBInstances.append(instance['DBInstanceIdentifier'])
+
+    return DBInstances


### PR DESCRIPTION
Backend to get all rds instances of a user. Currently untested as mocking aws objects still needs to be explored.